### PR TITLE
[Docs] Make everything tabs except yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,14 +7,8 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.go]
 indent_style = tab
 
-[Makefile]
-indent_style = tab
-
-[.github/workflows/*.yml]
+[*.yml]
 indent_sytle = space
 indent_size = 2
-


### PR DESCRIPTION
## Old behavior
Specified tabs for go and Makefiles and spaces for workflow yaml.

## New behavior
Everything is tabs by default.

## Additional info (related issues, images, etc.)
I could not stop myself.
