### PR TITLE
[Dev] Fix .editorconfig typo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ trim_trailing_whitespace = true
 indent_style = tab
 
 [*.yml]
-indent_sytle = space
+indent_style = space
 indent_size = 2


### PR DESCRIPTION
## Old behavior
Typo in .editorconfig broke yaml editing.

## New behavior
Fixed typo

## Additional info (related issues, images, etc.)
Recreation of #26 on the correct tip
