### PR TITLE
[Dev] Don't re-run pr-check CI for pushes to PR branch

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,7 +1,7 @@
 name: PR Title Check
 on:
   pull_request:
-    types: [edited, opened, reopened, synchronize]
+    types: [edited, opened, reopened]
 
 jobs:
   title-check:


### PR DESCRIPTION
## Old behavior
PR title check runs for pull requests every time the branch gets pushes even though it only checks the title.

## New behavior
Only run PR title check when a new pull request is opened or the title/body is edited.