### PR TITLE
[Dev] Use make lint instead of golangci-lint-action

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -53,11 +53,11 @@ jobs:
       - name: Cache golangci
         uses: actions/cache@v1
         with:
-          path: ~/.golangci-cache
+          path: ${{ github.workspace }}/.golangci-cache
           key: golangci-${{ hashFiles('**/go.mod') }}
       - run: make lint
         env:
-          GOLANGCI_LINT_CACHE: ~/.golangci-cache
+          GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.golangci-cache
   unittest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -51,7 +51,7 @@ jobs:
           cache-dependency-path: app/go.sum
       - run: make install-golangci
       - name: Cache golangci
-        uses: action/cache@v1
+        uses: actions/cache@v1
         with:
           path: ~/.golangci-cache
           key: golangci-${{ hashFiles('**/go.mod') }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -49,10 +49,15 @@ jobs:
         with:
           go-version-file: app/go.mod
           cache-dependency-path: app/go.sum
-      - uses: golangci/golangci-lint-action@v3
+      - run: make install-golangci
+      - name: Cache golangci
+        uses: action/cache@v1
         with:
-          version: latest
-          working-directory: app
+          path: ~/.golangci-cache
+          key: golangci-${{ hashFiles('**/go.mod') }}
+      - run: make lint
+        env:
+          GOLANGCI_LINT_CACHE: ~/.golangci-cache
   unittest:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ go.work
 
 # Editor environments
 .vscode/
+
+# Linter cache
+.golangci-cache/


### PR DESCRIPTION
## Old behavior
We can't do multiple modules easily with golangci-lint-action

## New behavior
 We run `make lint` and cache the golangci-lint cache ourselves.