### PR TITLE
[Feature] Add database and /api/submit pathway

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"log"
+	"net/http"
+
+	"github.com/google/uuid"
 
 	"github.com/gin-gonic/gin"
 )
@@ -19,8 +22,41 @@ func main() {
 	}
 
 	router.Static("/", "./www")
+	router.POST("/api/submit", postUserSubmission)
 
 	if err := router.Run("0.0.0.0:8080"); err != nil {
 		log.Fatal(err)
 	}
+}
+
+type score struct {
+	Participation float64 `json:"participation"`
+	Collaboration float64 `json:"collaboration"`
+	Contribution  float64 `json:"contribution"`
+	Attitude      float64 `json:"attitude"`
+	Goals         float64 `json:"goals"`
+}
+
+type groupData struct {
+	Name    string    `json:"name"`
+	Scores  []float64 `json:"scores"`
+	Comment string    `json:"comment"`
+}
+type userSubmission struct {
+	StudentName  string      `json:"studentName"`
+	StudentGroup string      `json:"studentGroup"`
+	GroupSize    int64       `json:"groupSize"`
+	GroupData    []groupData `json:"groupsData"`
+}
+
+func postUserSubmission(c *gin.Context) {
+	submission := userSubmission{}
+	c.BindJSON(&submission)
+	log.Println("postUserSubmission: got ", submission)
+	subUUID := uuid.NewString()
+	log.Println(subUUID)
+	res := struct {
+		Uuid string `json:"uuid"`
+	}{subUUID}
+	c.JSON(http.StatusOK, res)
 }

--- a/app/go.mod
+++ b/app/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.9.1
+	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.3.0
 )
 

--- a/app/go.mod
+++ b/app/go.mod
@@ -2,7 +2,10 @@ module github.com/cprbucat2/team-feedback
 
 go 1.20
 
-require github.com/gin-gonic/gin v1.9.1
+require (
+	github.com/gin-gonic/gin v1.9.1
+	github.com/google/uuid v1.3.0
+)
 
 require (
 	github.com/bytedance/sonic v1.9.1 // indirect

--- a/app/go.mod
+++ b/app/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-sql-driver/mysql v1.7.1
-	github.com/google/uuid v1.3.0
 )
 
 require (

--- a/app/go.sum
+++ b/app/go.sum
@@ -20,6 +20,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=

--- a/app/go.sum
+++ b/app/go.sum
@@ -28,8 +28,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/app/go.sum
+++ b/app/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/app/www/submit.js
+++ b/app/www/submit.js
@@ -37,7 +37,8 @@ function collect_scores(table) {
  */
 function submit_form() {
 	// Collect feedback score table data.
-	const submissions = collect_scores(document.querySelector(".feedback-data__score-table"));
+	const entries = collect_scores(document.querySelector(".feedback-data__score-table"));
+	/** @type {string} */
 	const improvement = document.querySelector("#self_improvement").value;
 
 	const comments = [];
@@ -46,18 +47,18 @@ function submit_form() {
 			comments.push(e.value);
 		}
 	});
-	if (submissions.length !== comments.length) {
+	if (entries.length !== comments.length) {
 		console.error("Score table and comment rows do not match.");
 		/** @todo Make this a fatal error once pages are generated. */
 	}
-	for (let i = 0; i < submissions.length; ++i) {
-		submissions[i].comment = comments[i];
+	for (let i = 0; i < entries.length; ++i) {
+		entries[i].comment = comments[i];
 	}
 
 	// Create Submission object.
 	const membersubmission = {
-		author: scores[0].name,
-		submissions,
+		author: entries[0].name,
+		entries,
 		improvement
 	};
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 services:
-  TeamFeedback-dev:
+  app-dev:
     image: team-feedback
     build:
       context: .
@@ -11,3 +11,33 @@ services:
       - ./app/www:/www:ro
     ports:
       - 8080:8080
+    environment:
+      MYSQL_HOST: mysql
+      MYSQL_USER: root
+      MYSQL_PASSWORD: example
+      MYSQL_DB: feedback
+    depends_on:
+      mysql:
+        condition: service_healthy
+  mysql:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: feedback
+    volumes:
+      - mysql-data-dev:/var/lib/mysql
+      - ./sql:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "curl", "-f", "localhost:3306"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 3307:8080
+
+volumes:
+  mysql-data-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 services:
-  TeamFeedback:
+  app:
     image: team-feedback
     build:
       context: .
@@ -9,3 +9,33 @@ services:
     tty: true # Get colorized Gin output.
     ports:
       - 8080:8080
+    environment:
+      MYSQL_HOST: mysql
+      MYSQL_USER: root
+      MYSQL_PASSWORD: example
+      MYSQL_DB: feedback
+    depends_on:
+      mysql:
+        condition: service_healthy
+  mysql:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: feedback
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./sql:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "curl", "-f", "localhost:3306"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 3307:8080
+
+volumes:
+  mysql-data:

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -13,15 +13,16 @@ create table members (
 
 create table membersubmissions (
 	ID int auto_increment not null,
+	UUID binary(16) not null, -- A uuid_to_bin encoded uuid.
 	Author int not null,
-	Submissions varchar(2400) not null, -- A list of up to 100 base64 encoded UUIDs to submissions.
+	Submissions varchar(255) not null, -- A list of submission IDs.
 	Improvement varchar(255) not null,
 	primary key (ID)
 );
 
 create table submissions (
 	ID int auto_increment not null,
-	UUID char(24) not null, -- A base64 encoded UUID.
+	Member int not null,
 	Participation float not null,
 	Collaboration float not null,
 	Contribution float not null,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,26 +1,32 @@
-create table teams (
-  ID int auto_increment not null,
-	TeamName varchar(255) not null,
-  Members varchar(255) not null,
-  primary key (ID)
-);
+drop table if exists teams;
+drop table if exists members;
+drop table if exists membersubmissions;
+drop table if exists submissions;
 
-create table members (
+create table teams (
 	ID int auto_increment not null,
-	MemberName varchar(255) not null,
+	Name varchar(255) not null,
+	Members varchar(255) not null,
 	primary key (ID)
 );
 
-create table membersubmissions (
+create table users (
 	ID int auto_increment not null,
-	UUID binary(16) not null, -- A uuid_to_bin encoded uuid.
-	Author int not null,
-	Submissions varchar(255) not null, -- A list of submission IDs.
-	Improvement varchar(255) not null,
+	Name varchar(255) not null,
+	TeamID int not null,
 	primary key (ID)
 );
 
 create table submissions (
+	ID int auto_increment not null,
+	UUID binary(16) not null, -- A uuid_to_bin encoded uuid.
+	Author int not null,
+	Entries varchar(255) not null, -- A list of submission IDs.
+	Improvement varchar(255) not null,
+	primary key (ID)
+);
+
+create table memberentries (
 	ID int auto_increment not null,
 	Member int not null,
 	Participation float not null,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -22,7 +22,6 @@ insert into users (name, team_id) values ("nobody", 1);
 
 create table submissions (
 	id bigint auto_increment not null primary key,
-	UUID binary(16) not null, -- A uuid_to_bin encoded uuid.
 	author bigint not null,
 	improvement varchar(255) not null,
 	index (author),

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,32 @@
+create table teams (
+  ID int auto_increment not null,
+	TeamName varchar(255) not null,
+  Members varchar(255) not null,
+  primary key (ID)
+);
+
+create table members (
+	ID int auto_increment not null,
+	MemberName varchar(255) not null,
+	primary key (ID)
+);
+
+create table membersubmissions (
+	ID int auto_increment not null,
+	Author int not null,
+	Submissions varchar(2400) not null, -- A list of up to 100 base64 encoded UUIDs to submissions.
+	Improvement varchar(255) not null,
+	primary key (ID)
+);
+
+create table submissions (
+	ID int auto_increment not null,
+	UUID char(24) not null, -- A base64 encoded UUID.
+	Participation float not null,
+	Collaboration float not null,
+	Contribution float not null,
+	Attitude float not null,
+	Goals float not null,
+	Comment varchar(255),
+	primary key(ID)
+);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,39 +1,46 @@
 drop table if exists teams;
-drop table if exists members;
-drop table if exists membersubmissions;
+drop table if exists users;
 drop table if exists submissions;
+drop table if exists memberentries;
 
 create table teams (
-	ID int auto_increment not null,
-	Name varchar(255) not null,
-	Members varchar(255) not null,
-	primary key (ID)
+	id bigint auto_increment not null primary key,
+	name varchar(255) not null
 );
+
+insert into teams (name) values ("none");
 
 create table users (
-	ID int auto_increment not null,
-	Name varchar(255) not null,
-	TeamID int not null,
-	primary key (ID)
+	id bigint auto_increment not null primary key,
+	name varchar(255) not null,
+	team_id bigint not null,
+	index (team_id),
+	foreign key (team_id) references teams (id)
 );
+
+insert into users (name, team_id) values ("nobody", 1);
 
 create table submissions (
-	ID int auto_increment not null,
+	id bigint auto_increment not null primary key,
 	UUID binary(16) not null, -- A uuid_to_bin encoded uuid.
-	Author int not null,
-	Entries varchar(255) not null, -- A list of submission IDs.
-	Improvement varchar(255) not null,
-	primary key (ID)
+	author bigint not null,
+	improvement varchar(255) not null,
+	index (author),
+	foreign key (author) references users (id)
 );
 
-create table memberentries (
-	ID int auto_increment not null,
-	Member int not null,
+create table entries (
+	id bigint auto_increment not null primary key,
+	submission_id bigint not null,
+	member bigint not null,
 	Participation float not null,
 	Collaboration float not null,
 	Contribution float not null,
 	Attitude float not null,
 	Goals float not null,
 	Comment varchar(255),
-	primary key(ID)
+	index (submission_id),
+	foreign key (submission_id) references submissions (id),
+	index (member),
+	foreign key (member) references users (id)
 );


### PR DESCRIPTION
## Old behavior
No storage or collection of submitted data.

## New behavior
Adds MySQL database to Docker compose. Also adminer to view the database.
Adds SQL schema with `teams`, `users`, `submissions`, and `entries` tables.
Adds the POST route `/api/submit` which adds a submission and the associated entries.
Notes:
- Team names, user names, and comments are limited to 255 characters. This is not currently communicated to users on `index.html`.
  - It may make sense to limit `<textarea>` input to 255 characters.
  - Or increase the limit on the table (and still limit input).

## Additional info (related issues, images, etc.)
Needs #41 and #47. Closes #4.
