### PR TITLE
[Dev] [Docs] Adds docker test stage and updates README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,17 @@ EXPOSE 8080
 ENTRYPOINT [ "/tf-server" ]
 
 LABEL Name=team-feedback Version=0.0.0
+
+# Test stage
+FROM golang:alpine as test
+RUN apk add make git build-base
+
+WORKDIR /go/test
+COPY app/go.mod app/go.sum ./
+RUN go mod download && go mod verify
+
+COPY app/Makefile ./
+RUN CGO_ENABLED=0 make install-golangci
+
+COPY app .
+RUN CC=gcc CGO_ENABLED=1 make test

--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@
 ![Go CI](https://github.com/cprbucat2/team-feedback/actions/workflows/go-ci.yml/badge.svg)
 
 TeamFeedback is a Dockerized feedback solution for teams, with both a web server and serverless solution both written in Go. We aim to ease the submission and redistribution of course feedback, including any aggregation, anonymization, or editing that the coordinators wish to perform. Coordinators can create teams of any size and view/vet all data. Team members can only view feedback as it is redistributed to them (e.g., after aggregation). The web application has different views for each role, allowing coordinators to manage teams and review data while students submit and review feedback. The serverless TeamFeedback exists to support coordinators who do not want to host the Dockerized database and web server. The local tool can generate static pages (with local resources) that collect, aggregate, and distribute data to the specific team members. Our stack includes Docker, MySQL, Go Gin, HTML, CSS, and JavaScript.
+
+## Installation
+We use Docker for our app, so installation is as easy as:
+```sh
+git clone https://github.com/cprbucat2/team-feedback
+cd team-feedback
+docker compose up
+```
+
+## Development
+We provide a separate Docker compose script for development with `/app/www` bind
+mounted. Run it with:
+```sh
+docker compose -f docker-compose-dev.yml up
+```
+Testing can be performed via Make with `make -C app test` or with Docker via
+`docker build --target=test .` where build status indicates test success.

--- a/app/Makefile
+++ b/app/Makefile
@@ -4,6 +4,7 @@ VERSION := 0.0.0
 
 GOFLAGS = -ldflags "-X github.com/cprbucat2/team-feedback.Version=$(VERSION)" -trimpath -mod=readonly
 GOTESTFLAGS ?= -race
+GOPATH ?= $(shell go env GOPATH)
 
 build: tf-server
 
@@ -33,7 +34,13 @@ install-golangci:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1
 
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1 run
+	@if [ -x "$(GOPATH)/bin/golangci-lint" ]; then \
+		echo "$(GOPATH)/bin/golangci-lint run"; \
+		$(GOPATH)/bin/golangci-lint run; \
+	else \
+		echo "go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1 run"; \
+		go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1 run; \
+	fi
 
 test: vet fmt lint unittest
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,8 @@ services:
     image: team-feedback
     build:
       context: .
-      dockerfile: ./app/Dockerfile
+      dockerfile: ./Dockerfile
+      target: server
     tty: true # Get colorized Gin output.
     volumes:
       - ./app/www:/www:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     image: team-feedback
     build:
       context: .
-      dockerfile: ./app/Dockerfile
+      dockerfile: ./Dockerfile
+      target: server
     tty: true # Get colorized Gin output.
     ports:
       - 8080:8080


### PR DESCRIPTION
## Old behavior
No Docker documentation.
Hard to run make test in docker.
`make lint` runs go build every time.

## New behavior
Added documentation and added a docker test stage.
`make lint` runs the installed golangci-lint if found.
Moved Dockerfile up.