### PR TITLE
[Dev] Add prereqs to make build

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -13,7 +13,7 @@ run: build
 tidy:
 	go mod tidy
 
-tf-server:
+tf-server: app.go go.sum go.mod
 	go build $(GOFLAGS) -o $@ .
 
 unittest coverage.out:


### PR DESCRIPTION
## Old behavior
No prereqs so `make build` never runs without `make clean` or `-B`.

## New behavior
tf-server has prereqs so make build runs when app.go or go.mod changes.