### PR TITLE
[Feature] HTTPS and CA Certificates

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,10 @@
 # Build stage
 FROM golang:alpine AS builder
 
-RUN apk add make git
+RUN apk add make git openssl
+
+WORKDIR /etc/ssl/certs
+RUN openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj "/C=US/ST=New York/O=Team Feedback/CN=localhost/T=dev"
 
 WORKDIR /app
 
@@ -17,6 +20,7 @@ FROM scratch as server
 
 # Get latest CA certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/ssl/certs/key.pem /etc/ssl/certs/cert.pem /etc/ssl/certs/
 
 COPY --from=builder /app/LICENSE /LICENSE
 COPY --from=builder /app/tf-server /tf-server

--- a/app/app.go
+++ b/app/app.go
@@ -20,7 +20,7 @@ func main() {
 
 	router.Static("/", "./www")
 
-	if err := router.Run("0.0.0.0:8080"); err != nil {
+	if err := router.RunTLS("0.0.0.0:8080", "/etc/ssl/certs/cert.pem", "/etc/ssl/certs/key.pem"); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Old behavior
Cannot have authentication without HTTPS.

## New behavior
- [x] Installed user CA cerificates into the production Docker image 
- [x] Generated CA certificates for development
- [x] Added HTTPS to Go server
- [ ] Change port number from 8080 to something else

## Additional info (related issues, images, etc.)
Closes #62
